### PR TITLE
Protect late destructor call to FileSystem

### DIFF
--- a/src/XrdCl/XrdClFileSystem.cc
+++ b/src/XrdCl/XrdClFileSystem.cc
@@ -344,8 +344,11 @@ namespace XrdCl
   //----------------------------------------------------------------------------
   FileSystem::~FileSystem()
   {
-    if( !pPlugIn )
-      DefaultEnv::GetForkHandler()->UnRegisterFileSystemObject( this );
+    if( !pPlugIn ) {
+      ForkHandler* handler = DefaultEnv::GetForkHandler();
+      if( handler ) 
+	handler->UnRegisterFileSystemObject( this );
+    }
     delete pUrl;
     delete pPlugIn;
   }


### PR DESCRIPTION
ROOT indirectly binds the destruction of a FileSystem to a the global
gROOT. This can lead to the ForkHandler being deleted before the
FileSystem is deleted.