### PR TITLE
Pass correct size of buffer to avoid groupname truncation.

### DIFF
--- a/src/XrdSecunix/XrdSecProtocolunix.cc
+++ b/src/XrdSecunix/XrdSecProtocolunix.cc
@@ -107,7 +107,7 @@ XrdSecCredentials *XrdSecProtocolunix::getCredentials(XrdSecParameters *noparm,
 
 // Get the group name
 //
-   if ((n = XrdOucUtils::GroupName(getegid(), Bp+1, Blen-1)))
+   if ((n = XrdOucUtils::GroupName(getegid(), Bp+1, sizeof(Buff)-Blen)))
       {*Bp = ' '; Blen += (n+1);}
 
 // Return the credentials


### PR DESCRIPTION
(cherry picked from commit 36b90429344732a8712976b6e7492320dd3dc458 on xrootd/master)
