### PR TITLE
Make sure the wakePend flag does not incur undefined behavior.

### DIFF
--- a/src/XrdSys/XrdSysIOEvents.hh
+++ b/src/XrdSys/XrdSysIOEvents.hh
@@ -36,6 +36,14 @@
 
 #include "XrdSys/XrdSysPthread.hh"
 
+#if __cplusplus >= 201103L
+#define USE_CPP11_ATOMICS
+#endif
+
+#ifdef USE_CPP11_ATOMICS
+#include <atomic>
+#endif
+
 //-----------------------------------------------------------------------------
 //! IOEvents
 //!
@@ -506,7 +514,11 @@ PipeData        reqBuff;    // Buffer used by poller thread to recv data
 char           *pipeBuff;   // Read resumption point in buffer
 int             pipeBlen;   // Number of outstanding bytes
 char            tmoMask;    // Timeout mask
+#ifdef USE_CPP11_ATOMICS
+std::atomic<bool> wakePend;   // Wakeup is effectively pending (don't send)
+#else
 bool            wakePend;   // Wakeup is effectively pending (don't send)
+#endif
 bool            chDead;     // True if channel deleted by callback
 
 static time_t   maxTime;    // Maximum time allowed

--- a/src/XrdSys/XrdSysIOEventsPollE.icc
+++ b/src/XrdSys/XrdSysIOEventsPollE.icc
@@ -207,8 +207,13 @@ void XrdSys::IOEvents::PollE::Begin(XrdSysSemaphore *syncsem,
 //
    do {do {numpolled = epoll_wait(pollDfd, pollTab, pollMax, TmoGet());}
           while (numpolled < 0 && errno == EINTR);
-       wakePend = true; numPoll = numpolled;
-            if (numpolled == 0) CbkTMO();
+#ifdef USE_CPP11_ATOMICS
+       wakePend.store(true, std::memory_order_release);
+#else
+       wakePend = true;
+#endif
+       numPoll = numpolled;
+       if (numpolled == 0) CbkTMO();
        else if (numpolled <  0)
                {int rc = errno;
                 cerr <<"EPoll: " <<strerror(rc) <<" polling for events" <<endl;


### PR DESCRIPTION
The wakePend flag currently has undefined behavior as multiple threads
read and write to it without a consistent locking mechanism.  This
switches writes and reads to use C++11's release-consume ordering
when available.  Without this patch, we have undefined behavior - which
is illegal with C++11.

The release-consume ordering is sufficient to guarantee atomicity
and the ordering of wakePend writes; other than that, it's a very
weak memory model.  In practice, this is a guarantee already provided
by all interesting architectures (it only generates different assembler
on DEC Alpha).

Fixes #167.  Upstream states they do not care about undefined behavior here, so putting it into the cms/v4.0.4 branch.