### PR TITLE
Set xrootd release version (v4.0.4)

### DIFF
--- a/VERSION_INFO
+++ b/VERSION_INFO
@@ -1,1 +1,3 @@
-$Format:RefNames: %d%nShortHash: %h%nDate: %ai%n$
+RefNames:  (v4.0.4, stable-4.0.x)
+ShortHash: e4f13bd
+Date: 2014-10-22 14:51:39 +0200


### PR DESCRIPTION
Without this information generated headers provide wrong information
and creates failures while compiling ROOT6 + CMake.

This fixes `XrdVersion.hh` header.

```
--- /afs/cern.ch/cms/sw/ReleaseCandidates/vol0/slc6_amd64_gcc491/external/xrootd/4.0.4-eccfad/include/xrootd/XrdVersion.hh      2015-05-25 11:28:26.000000001 +0200
+++ a/slc6_amd64_gcc491/external/xrootd/4.0.4-cms/include/xrootd/XrdVersion.hh  2015-05-27 13:10:49.000000000 +0200
@@ -31,14 +31,14 @@
 #ifndef __XRD_VERSION_H__
 #define __XRD_VERSION_H__

-#define XrdVERSION  "unknown"
+#define XrdVERSION  "v4.0.4"

 // Numeric representation of the version tag
 // The format for the released code is: xyyzz, where: x is the major version,
 // y is the minor version and zz is the bugfix revision number
 // For the non-released code the value is 1000000
 #define XrdVNUMUNK  1000000
-#define XrdVNUMBER  1000000
+#define XrdVNUMBER  40004

 #if XrdDEBUG
 #define XrdVSTRING XrdVERSION "_dbg"
```

I see this being used in ROOT source code (proofd).

Signed-off-by: David Abdurachmanov <David.Abdurachmanov@cern.ch>