### PR TITLE
Unlock stream (cms-externals versionj)

### DIFF
--- a/src/XrdCl/XrdClStream.cc
+++ b/src/XrdCl/XrdClStream.cc
@@ -887,7 +887,10 @@ namespace XrdCl
                                             pStreamNum,
                                             *pChannelData );
     if( !st.IsOK() )
+    {
+      scopedLock.UnLock();
       OnError( substream, st );
+    }
   }
 
   //----------------------------------------------------------------------------


### PR DESCRIPTION
OnReadTimeout will call OnError with the Stream's lock held.
This causes OnError to invoke the user's callback with the
Stream lock held, possibly causing a lock ordering issue.

This fixes an observed deadlock within CMSSW over the following
objects:

Thread 1
    FileStateHandler::VectorRead takes FileStateHandler lock
    Stream::Send tries to take Stream lock

Thread 5
    FileTimer::Run takes FileTimer lock
    FileStateHandler::Tick tries to take FileStateHandler

Thread 6
    Stream::OnReadTimeout takes Stream lock
    DelayedClose::HandleResponseWithHosts  (this is callback code in CMSSW); this deletes a File object, which eventually calls
    FileTimer::UnRegisterFileObject tries to take FileTimer lock

See discussion in https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1362/1/1/1/1/1/1/1/1/1/1/1/1/1/2.html